### PR TITLE
Refactor FileExplorer

### DIFF
--- a/components/layout/FileExplorer.tsx
+++ b/components/layout/FileExplorer.tsx
@@ -1,27 +1,15 @@
 "use client"
 
 import React, { useState, useRef, useEffect } from "react"
-import { File, Folder, ChevronRight, ChevronDown, MoreVertical, Edit2, Plus, FilePlus, FolderPlus } from "lucide-react"
+import { File, Folder } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { FileNode } from "@/types"
 import { useAnalysisStore } from "@/stores/useAnalysisStore"
 import { Input } from "@/components/ui/input"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+import { FileTreeNode } from "./FileTreeNode"
 
 export function FileExplorer() {
-  const { 
-    fileTree, 
-    expandedFolders, 
-    toggleFolder, 
-    openFile, 
-    renamingNode, 
-    setRenamingNode, 
-    renameNode,
+  const {
+    fileTree,
     creatingNodeType,
     creatingNodeParentId,
     setCreatingNode,
@@ -30,291 +18,40 @@ export function FileExplorer() {
     draggedNode,
     dragOverNode,
     dragPosition,
-    setDraggedNode,
     setDragOverNode,
-    moveNode
+    moveNode,
+    setDraggedNode,
   } = useAnalysisStore()
+
   const [tempName, setTempName] = useState("")
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
-    if ((renamingNode || creatingNodeType) && inputRef.current) {
+    if (creatingNodeParentId === null && creatingNodeType && inputRef.current) {
       inputRef.current.focus()
       inputRef.current.select()
     }
-  }, [renamingNode, creatingNodeType])
-
-  const handleRename = (nodeId: string, currentName: string) => {
-    setTempName(currentName)
-    setRenamingNode(nodeId)
-  }
-
-  const handleRenameSubmit = (nodeId: string) => {
-    if (tempName.trim()) {
-      renameNode(nodeId, tempName.trim())
-    }
-    setRenamingNode(null)
-    setTempName("")
-  }
+  }, [creatingNodeParentId, creatingNodeType])
 
   const handleCreateSubmit = () => {
     if (tempName.trim() && creatingNodeType) {
       if (creatingNodeType === "folder") {
-        createNewFolder(creatingNodeParentId, tempName.trim())
+        createNewFolder(null, tempName.trim())
       } else {
-        createNewFile(creatingNodeParentId, tempName.trim())
+        createNewFile(null, tempName.trim())
       }
     }
     setCreatingNode(null, null)
     setTempName("")
   }
 
-  const handleRenameCancel = () => {
-    setRenamingNode(null)
+  const handleCancel = () => {
     setCreatingNode(null, null)
     setTempName("")
-  }
-
-  const handleDragStart = (e: React.DragEvent, nodeId: string) => {
-    setDraggedNode(nodeId)
-    e.dataTransfer.effectAllowed = "move"
-    e.dataTransfer.setData("text/plain", nodeId)
-  }
-
-  const handleDragOver = (e: React.DragEvent, nodeId: string, position: "before" | "after" | "inside") => {
-    e.preventDefault()
-    e.stopPropagation()
-    
-    if (draggedNode && draggedNode !== nodeId) {
-      setDragOverNode(nodeId, position)
-      e.dataTransfer.dropEffect = "move"
-    }
-  }
-
-  const handleDragLeave = (e: React.DragEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    
-    // Only clear if we're actually leaving the element (not entering a child)
-    const rect = e.currentTarget.getBoundingClientRect()
-    const x = e.clientX
-    const y = e.clientY
-    
-    if (x < rect.left || x >= rect.right || y < rect.top || y >= rect.bottom) {
-      setDragOverNode(null, null)
-    }
-  }
-
-  const handleDrop = (e: React.DragEvent, nodeId: string, position: "before" | "after" | "inside") => {
-    e.preventDefault()
-    e.stopPropagation()
-    
-    if (draggedNode && draggedNode !== nodeId) {
-      moveNode(draggedNode, nodeId, position)
-    }
-    
-    setDraggedNode(null)
-    setDragOverNode(null, null)
-  }
-
-  const handleDragEnd = () => {
-    setDraggedNode(null)
-    setDragOverNode(null, null)
-  }
-
-  const getDropIndicatorClass = (nodeId: string, position: "before" | "after" | "inside") => {
-    if (dragOverNode === nodeId && dragPosition === position && draggedNode) {
-      switch (position) {
-        case "before":
-          return "border-t-2 border-blue-500"
-        case "after":
-          return "border-b-2 border-blue-500"
-        case "inside":
-          return "bg-blue-50 border-blue-200 border-2 border-dashed"
-        default:
-          return ""
-      }
-    }
-    return ""
-  }
-
-  const renderFileTree = (nodes: FileNode[], depth = 0) => {
-    return nodes.map((node) => (
-      <div key={node.id}>
-        {/* Drop zone before the node */}
-        <div
-          className={cn(
-            "h-1 transition-all",
-            getDropIndicatorClass(node.id, "before")
-          )}
-          onDragOver={(e) => handleDragOver(e, node.id, "before")}
-          onDrop={(e) => handleDrop(e, node.id, "before")}
-        />
-        
-        <div
-          draggable={!renamingNode && !creatingNodeType}
-          onDragStart={(e) => handleDragStart(e, node.id)}
-          onDragEnd={handleDragEnd}
-          onDragOver={(e) => {
-            if (node.type === "folder") {
-              handleDragOver(e, node.id, "inside")
-            } else {
-              e.preventDefault()
-            }
-          }}
-          onDragLeave={handleDragLeave}
-          onDrop={(e) => {
-            if (node.type === "folder") {
-              handleDrop(e, node.id, "inside")
-            }
-          }}
-          className={cn(
-            "group flex items-center gap-2 px-2 py-1 hover:bg-accent cursor-pointer text-sm relative transition-all",
-            `ml-${depth * 4}`,
-            draggedNode === node.id && "opacity-50",
-            getDropIndicatorClass(node.id, "inside")
-          )}
-        >
-          <div
-            className="flex items-center gap-2 flex-1"
-            onClick={() => {
-              if (node.type === "folder") {
-                toggleFolder(node.id)
-              } else {
-                openFile(node)
-              }
-            }}
-          >
-            {node.type === "folder" ? (
-              <>
-                {expandedFolders.has(node.id) ? (
-                  <ChevronDown className="h-4 w-4" />
-                ) : (
-                  <ChevronRight className="h-4 w-4" />
-                )}
-                <Folder className="h-4 w-4" />
-              </>
-            ) : (
-              <>
-                <div className="w-4" />
-                <File className="h-4 w-4" />
-              </>
-            )}
-            {renamingNode === node.id ? (
-              <Input
-                ref={inputRef}
-                value={tempName}
-                onChange={(e) => setTempName(e.target.value)}
-                onBlur={() => handleRenameSubmit(node.id)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    handleRenameSubmit(node.id)
-                  } else if (e.key === "Escape") {
-                    handleRenameCancel()
-                  }
-                }}
-                className="h-6 py-0 px-1 text-sm"
-                onClick={(e) => e.stopPropagation()}
-              />
-            ) : (
-              <span className="truncate">{node.name}</span>
-            )}
-          </div>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                className="opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent rounded"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <MoreVertical className="h-3 w-3" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                onClick={(e) => {
-                  e.stopPropagation()
-                  handleRename(node.id, node.name)
-                }}
-              >
-                <Edit2 className="h-4 w-4 mr-2" />
-                Rename
-              </DropdownMenuItem>
-              {node.type === "folder" && (
-                <>
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      setCreatingNode("folder", node.id)
-                    }}
-                  >
-                    <FolderPlus className="h-4 w-4 mr-2" />
-                    New Folder
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      setCreatingNode("file", node.id)
-                    }}
-                  >
-                    <FilePlus className="h-4 w-4 mr-2" />
-                    New File
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-        {node.type === "folder" && expandedFolders.has(node.id) && (
-          <div>
-            {node.children && renderFileTree(node.children, depth + 1)}
-            {creatingNodeParentId === node.id && creatingNodeType && (
-              <div
-                className={cn(
-                  "flex items-center gap-2 px-2 py-1 text-sm",
-                  `ml-${(depth + 1) * 4}`
-                )}
-              >
-                <div className="w-4" />
-                {creatingNodeType === "folder" ? (
-                  <Folder className="h-4 w-4" />
-                ) : (
-                  <File className="h-4 w-4" />
-                )}
-                <Input
-                  ref={inputRef}
-                  value={tempName}
-                  onChange={(e) => setTempName(e.target.value)}
-                  onBlur={handleCreateSubmit}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      handleCreateSubmit()
-                    } else if (e.key === "Escape") {
-                      handleRenameCancel()
-                    }
-                  }}
-                  placeholder={creatingNodeType === "folder" ? "New folder name" : "New file name"}
-                  className="h-6 py-0 px-1 text-sm"
-                />
-              </div>
-            )}
-          </div>
-        )}
-        
-        {/* Drop zone after the node */}
-        <div
-          className={cn(
-            "h-1 transition-all",
-            getDropIndicatorClass(node.id, "after")
-          )}
-          onDragOver={(e) => handleDragOver(e, node.id, "after")}
-          onDrop={(e) => handleDrop(e, node.id, "after")}
-        />
-      </div>
-    ))
   }
 
   return (
-    <div 
+    <div
       className="py-2"
       onDragOver={(e) => {
         if (fileTree.length === 0) {
@@ -326,12 +63,15 @@ export function FileExplorer() {
         if (draggedNode && fileTree.length === 0) {
           e.preventDefault()
           moveNode(draggedNode, null, "inside")
+          setDraggedNode(null)
+          setDragOverNode(null, null)
         }
       }}
     >
-      {renderFileTree(fileTree)}
-      
-      {/* Root level drop zone */}
+      {fileTree.map((node) => (
+        <FileTreeNode key={node.id} node={node} depth={0} />
+      ))}
+
       {fileTree.length > 0 && (
         <div
           className={cn(
@@ -348,11 +88,13 @@ export function FileExplorer() {
             if (draggedNode) {
               e.preventDefault()
               moveNode(draggedNode, null, "inside")
+              setDraggedNode(null)
+              setDragOverNode(null, null)
             }
           }}
         />
       )}
-      
+
       {creatingNodeParentId === null && creatingNodeType && (
         <div className="flex items-center gap-2 px-2 py-1 text-sm">
           {creatingNodeType === "folder" ? (
@@ -369,7 +111,7 @@ export function FileExplorer() {
               if (e.key === "Enter") {
                 handleCreateSubmit()
               } else if (e.key === "Escape") {
-                handleRenameCancel()
+                handleCancel()
               }
             }}
             placeholder={creatingNodeType === "folder" ? "New folder name" : "New file name"}
@@ -380,3 +122,4 @@ export function FileExplorer() {
     </div>
   )
 }
+

--- a/components/layout/FileTreeNode.tsx
+++ b/components/layout/FileTreeNode.tsx
@@ -1,0 +1,312 @@
+"use client"
+
+import React, { useState, useRef, useEffect } from "react"
+import { File, Folder, ChevronRight, ChevronDown, MoreVertical, Edit2, FilePlus, FolderPlus } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { FileNode } from "@/types"
+import { useAnalysisStore } from "@/stores/useAnalysisStore"
+import { Input } from "@/components/ui/input"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+interface FileTreeNodeProps {
+  node: FileNode
+  depth?: number
+}
+
+export function FileTreeNode({ node, depth = 0 }: FileTreeNodeProps) {
+  const {
+    expandedFolders,
+    toggleFolder,
+    openFile,
+    renamingNode,
+    setRenamingNode,
+    renameNode,
+    creatingNodeType,
+    creatingNodeParentId,
+    setCreatingNode,
+    createNewFolder,
+    createNewFile,
+    draggedNode,
+    dragOverNode,
+    dragPosition,
+    setDraggedNode,
+    setDragOverNode,
+    moveNode,
+  } = useAnalysisStore()
+
+  const [tempName, setTempName] = useState("")
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if ((renamingNode === node.id || creatingNodeParentId === node.id) && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [renamingNode, creatingNodeParentId, node.id])
+
+  const handleRename = () => {
+    setTempName(node.name)
+    setRenamingNode(node.id)
+  }
+
+  const handleRenameSubmit = () => {
+    if (tempName.trim()) {
+      renameNode(node.id, tempName.trim())
+    }
+    setRenamingNode(null)
+    setTempName("")
+  }
+
+  const handleCreateSubmit = () => {
+    if (tempName.trim() && creatingNodeType) {
+      if (creatingNodeType === "folder") {
+        createNewFolder(node.id, tempName.trim())
+      } else {
+        createNewFile(node.id, tempName.trim())
+      }
+    }
+    setCreatingNode(null, null)
+    setTempName("")
+  }
+
+  const handleRenameCancel = () => {
+    setRenamingNode(null)
+    setCreatingNode(null, null)
+    setTempName("")
+  }
+
+  const handleDragStart = (e: React.DragEvent) => {
+    setDraggedNode(node.id)
+    e.dataTransfer.effectAllowed = "move"
+    e.dataTransfer.setData("text/plain", node.id)
+  }
+
+  const handleDragOver = (e: React.DragEvent, position: "before" | "after" | "inside") => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    if (draggedNode && draggedNode !== node.id) {
+      setDragOverNode(node.id, position)
+      e.dataTransfer.dropEffect = "move"
+    }
+  }
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    const rect = e.currentTarget.getBoundingClientRect()
+    const x = e.clientX
+    const y = e.clientY
+
+    if (x < rect.left || x >= rect.right || y < rect.top || y >= rect.bottom) {
+      setDragOverNode(null, null)
+    }
+  }
+
+  const handleDrop = (e: React.DragEvent, position: "before" | "after" | "inside") => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    if (draggedNode && draggedNode !== node.id) {
+      moveNode(draggedNode, node.id, position)
+    }
+
+    setDraggedNode(null)
+    setDragOverNode(null, null)
+  }
+
+  const handleDragEnd = () => {
+    setDraggedNode(null)
+    setDragOverNode(null, null)
+  }
+
+  const getDropIndicatorClass = (position: "before" | "after" | "inside") => {
+    if (dragOverNode === node.id && dragPosition === position && draggedNode) {
+      switch (position) {
+        case "before":
+          return "border-t-2 border-blue-500"
+        case "after":
+          return "border-b-2 border-blue-500"
+        case "inside":
+          return "bg-blue-50 border-blue-200 border-2 border-dashed"
+        default:
+          return ""
+      }
+    }
+    return ""
+  }
+
+  return (
+    <div>
+      <div
+        className={cn("h-1 transition-all", getDropIndicatorClass("before"))}
+        onDragOver={(e) => handleDragOver(e, "before")}
+        onDrop={(e) => handleDrop(e, "before")}
+      />
+      <div
+        draggable={renamingNode === null && creatingNodeType === null}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragOver={(e) => {
+          if (node.type === "folder") {
+            handleDragOver(e, "inside")
+          } else {
+            e.preventDefault()
+          }
+        }}
+        onDragLeave={handleDragLeave}
+        onDrop={(e) => {
+          if (node.type === "folder") {
+            handleDrop(e, "inside")
+          }
+        }}
+        className={cn(
+          "group flex items-center gap-2 px-2 py-1 hover:bg-accent cursor-pointer text-sm relative transition-all",
+          `ml-${depth * 4}`,
+          draggedNode === node.id && "opacity-50",
+          getDropIndicatorClass("inside")
+        )}
+      >
+        <div
+          className="flex items-center gap-2 flex-1"
+          onClick={() => {
+            if (node.type === "folder") {
+              toggleFolder(node.id)
+            } else {
+              openFile(node)
+            }
+          }}
+        >
+          {node.type === "folder" ? (
+            <>
+              {expandedFolders.has(node.id) ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+              <Folder className="h-4 w-4" />
+            </>
+          ) : (
+            <>
+              <div className="w-4" />
+              <File className="h-4 w-4" />
+            </>
+          )}
+          {renamingNode === node.id ? (
+            <Input
+              ref={inputRef}
+              value={tempName}
+              onChange={(e) => setTempName(e.target.value)}
+              onBlur={handleRenameSubmit}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  handleRenameSubmit()
+                } else if (e.key === "Escape") {
+                  handleRenameCancel()
+                }
+              }}
+              className="h-6 py-0 px-1 text-sm"
+              onClick={(e) => e.stopPropagation()}
+            />
+          ) : (
+            <span className="truncate">{node.name}</span>
+          )}
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              className="opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent rounded"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <MoreVertical className="h-3 w-3" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation()
+                handleRename()
+              }}
+            >
+              <Edit2 className="h-4 w-4 mr-2" />
+              Rename
+            </DropdownMenuItem>
+            {node.type === "folder" && (
+              <>
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setCreatingNode("folder", node.id)
+                    setTempName("")
+                  }}
+                >
+                  <FolderPlus className="h-4 w-4 mr-2" />
+                  New Folder
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setCreatingNode("file", node.id)
+                    setTempName("")
+                  }}
+                >
+                  <FilePlus className="h-4 w-4 mr-2" />
+                  New File
+                </DropdownMenuItem>
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      {node.type === "folder" && expandedFolders.has(node.id) && (
+        <div>
+          {node.children && node.children.map((child) => (
+            <FileTreeNode key={child.id} node={child} depth={depth + 1} />
+          ))}
+          {creatingNodeParentId === node.id && creatingNodeType && (
+            <div
+              className={cn(
+                "flex items-center gap-2 px-2 py-1 text-sm",
+                `ml-${(depth + 1) * 4}`
+              )}
+            >
+              <div className="w-4" />
+              {creatingNodeType === "folder" ? (
+                <Folder className="h-4 w-4" />
+              ) : (
+                <File className="h-4 w-4" />
+              )}
+              <Input
+                ref={inputRef}
+                value={tempName}
+                onChange={(e) => setTempName(e.target.value)}
+                onBlur={handleCreateSubmit}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    handleCreateSubmit()
+                  } else if (e.key === "Escape") {
+                    handleRenameCancel()
+                  }
+                }}
+                placeholder={creatingNodeType === "folder" ? "New folder name" : "New file name"}
+                className="h-6 py-0 px-1 text-sm"
+              />
+            </div>
+          )}
+        </div>
+      )}
+      <div
+        className={cn("h-1 transition-all", getDropIndicatorClass("after"))}
+        onDragOver={(e) => handleDragOver(e, "after")}
+        onDrop={(e) => handleDrop(e, "after")}
+      />
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- split `FileExplorer` into smaller components
- new `FileTreeNode` handles recursive rendering

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_6844d7349cb4832b85a453a4f94baae9