### PR TITLE
Fix parameter tab layout

### DIFF
--- a/components/charts/EditModal/parameters/ParametersTab.tsx
+++ b/components/charts/EditModal/parameters/ParametersTab.tsx
@@ -28,24 +28,24 @@ export function ParametersTab({ editingChart, setEditingChart }: ParametersTabPr
   const [referenceLines, setReferenceLines] = useState<ReferenceLineConfig[]>([])
 
   return (
-    <div className="flex flex-col h-full gap-4">
+    <div className="flex flex-col h-full gap-4 overflow-hidden">
       <div className="flex-shrink-0">
-        <XParameterSettings 
-          editingChart={editingChart} 
-          setEditingChart={setEditingChart} 
+        <XParameterSettings
+          editingChart={editingChart}
+          setEditingChart={setEditingChart}
         />
       </div>
-      
-      <div className="max-h-[60vh] overflow-hidden">
-        <YParametersSettings 
-          editingChart={editingChart} 
-          setEditingChart={setEditingChart} 
+
+      <div className="flex-1 min-h-[8rem] overflow-hidden">
+        <YParametersSettings
+          editingChart={editingChart}
+          setEditingChart={setEditingChart}
         />
       </div>
-      
-      <div className="flex-shrink-0">
-        <ReferenceLinesSettings 
-          editingChart={editingChart} 
+
+      <div className="flex-1 min-h-[8rem] overflow-hidden">
+        <ReferenceLinesSettings
+          editingChart={editingChart}
           referenceLines={referenceLines}
           onUpdateReferenceLines={setReferenceLines}
         />

--- a/components/charts/EditModal/parameters/ReferenceLinesSettings.tsx
+++ b/components/charts/EditModal/parameters/ReferenceLinesSettings.tsx
@@ -92,8 +92,8 @@ export function ReferenceLinesSettings({ editingChart, referenceLines, onUpdateR
   }
 
   return (
-    <div className="border rounded-lg bg-muted/30">
-      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+    <div className="border rounded-lg bg-muted/30 h-full flex flex-col">
+      <Collapsible open={isOpen} onOpenChange={setIsOpen} className="flex flex-col flex-1">
         <div className="flex items-center gap-2 p-3">
           <CollapsibleTrigger className="flex items-center gap-2 text-left hover:bg-muted/50 transition-colors p-1 rounded">
             {isOpen ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
@@ -110,7 +110,7 @@ export function ReferenceLinesSettings({ editingChart, referenceLines, onUpdateR
             Add Reference Line
           </Button>
         </div>
-        <CollapsibleContent>
+        <CollapsibleContent className="flex-1 overflow-y-auto">
           <div className="px-3 pb-3">
 
       <div className="flex gap-2 mb-2 px-1 pb-1 border-b">
@@ -122,7 +122,7 @@ export function ReferenceLinesSettings({ editingChart, referenceLines, onUpdateR
         <div className="w-7"></div>
       </div>
 
-      <div className="space-y-2 max-h-48 overflow-y-auto">
+      <div className="space-y-2">
         {referenceLines.map((line) => (
           <div key={line.id} className="flex gap-2 p-1">
             <div className="w-24">

--- a/components/charts/EditModal/parameters/YParametersSettings.tsx
+++ b/components/charts/EditModal/parameters/YParametersSettings.tsx
@@ -332,8 +332,12 @@ export function YParametersSettings({ editingChart, setEditingChart }: YParamete
 
   return (
     <>
-      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <div className="border rounded-lg bg-muted/30">
+      <Collapsible
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        className="h-full flex flex-col"
+      >
+        <div className="border rounded-lg bg-muted/30 flex flex-col flex-1">
           <div className="flex items-center gap-2 p-3 border-b bg-muted/20">
             <CollapsibleTrigger className="flex items-center gap-2 text-left hover:bg-muted/50 transition-colors p-1 rounded">
               {isOpen ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
@@ -348,10 +352,8 @@ export function YParametersSettings({ editingChart, setEditingChart }: YParamete
               New Axis Group
             </Button>
           </div>
-          <CollapsibleContent>
-            <div className="px-3 pb-3">
-              <div className="max-h-[50vh] overflow-y-auto">
-                <div className="space-y-4">
+          <CollapsibleContent className="flex-1 overflow-y-auto">
+            <div className="px-3 pb-3 space-y-4">
                   {editingChart.yAxisParams && editingChart.yAxisParams.length > 0 ? (
                     Object.entries(groupParametersByAxis()).map(([axisNoStr, paramIndexes]) => {
                       const axisNo = parseInt(axisNoStr)
@@ -392,8 +394,6 @@ export function YParametersSettings({ editingChart, setEditingChart }: YParamete
                   ) : (
                     <p className="text-sm text-muted-foreground px-1">No Y parameters added yet.</p>
                   )}
-                </div>
-              </div>
             </div>
           </CollapsibleContent>
         </div>


### PR DESCRIPTION
## Summary
- ensure parameter sections have minimal heights
- allow sections to scroll individually and keep headers visible
- split remaining height between Y parameters and reference lines sections

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684576d90760832bb7860485e811f402