### PR TITLE
Fix Y Parameters header visibility

### DIFF
--- a/components/charts/EditModal/parameters/YParametersSettings.tsx
+++ b/components/charts/EditModal/parameters/YParametersSettings.tsx
@@ -338,7 +338,7 @@ export function YParametersSettings({ editingChart, setEditingChart }: YParamete
         className="h-full flex flex-col"
       >
         <div className="border rounded-lg bg-muted/30 flex flex-col flex-1">
-          <div className="flex items-center gap-2 p-3 border-b bg-muted/20">
+          <div className="flex items-center gap-2 p-3 border-b bg-muted/20 sticky top-0 z-10">
             <CollapsibleTrigger className="flex items-center gap-2 text-left hover:bg-muted/50 transition-colors p-1 rounded">
               {isOpen ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
               <h4 className="font-medium text-sm">Y Parameters Settings</h4>


### PR DESCRIPTION
## Summary
- keep the Y Parameters header visible when scrolling by making it sticky

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684579b69724832b8e61735c84588469