### PR TITLE
Fix reference line drag disappearing

### DIFF
--- a/components/charts/ChartPreview.tsx
+++ b/components/charts/ChartPreview.tsx
@@ -130,7 +130,7 @@ export function ChartPreview({ editingChart, selectedDataSourceItems, setEditing
   }
 
   useEffect(() => {
-    if (!svgRef.current) return
+    if (!svgRef.current || draggingLine) return
 
     const svg = d3.select(svgRef.current)
     svg.selectAll("*").remove()
@@ -159,7 +159,7 @@ export function ChartPreview({ editingChart, selectedDataSourceItems, setEditing
       renderEmptyChart(g, width, height, chartType)
     }
 
-  }, [editingChart, selectedDataSourceItems])
+  }, [editingChart, selectedDataSourceItems, draggingLine])
 
   // Separate effect for drawing reference lines to prevent full re-render during drag
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure chart does not fully rerender while dragging a reference line

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6846724cf85c832bb2b402127c612210