### PR TITLE
Fix tooltip hide timing when moving across markers

### DIFF
--- a/utils/chart/chartTooltipManager.ts
+++ b/utils/chart/chartTooltipManager.ts
@@ -55,7 +55,13 @@ export class ChartTooltipManager {
       onMouseMove: (event: MouseEvent) => {
         updateTooltipPosition(event)
       },
-      onMouseOut: () => {
+      onMouseOut: (event: MouseEvent) => {
+        // If moving to another marker within the chart, skip hiding
+        const related = event.relatedTarget as HTMLElement | null
+        if (related && related.closest(".markers")) {
+          return
+        }
+
         // Add a longer delay before hiding to prevent flickering
         this.hideTimeout = setTimeout(() => {
           hideTooltip()


### PR DESCRIPTION
## Summary
- prevent hideTooltip if pointer moves directly to another marker

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run type-check` *(fails with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e2e09537c832b9eb89d7584801e8f