### PR TITLE
Add draggable chart legend

### DIFF
--- a/components/charts/ChartLegend.tsx
+++ b/components/charts/ChartLegend.tsx
@@ -10,22 +10,44 @@ interface ChartLegendProps {
   dataSources: EventInfo[]
   dataSourceStyles?: { [dataSourceId: string]: DataSourceStyle }
   className?: string
+  style?: React.CSSProperties
+  onPointerDown?: React.PointerEventHandler<HTMLDivElement>
 }
 
-export const ChartLegend: React.FC<ChartLegendProps> = React.memo(({ dataSources, dataSourceStyles = {}, className }) => {
-  if (!dataSources || dataSources.length === 0) return null
+export const ChartLegend = React.memo(
+  React.forwardRef<HTMLDivElement, ChartLegendProps>(
+    ({
+      dataSources,
+      dataSourceStyles = {},
+      className,
+      style,
+      onPointerDown
+    }, ref) => {
+      if (!dataSources || dataSources.length === 0) return null
 
-  return (
-    <div className={cn("bg-white/80 rounded shadow p-1 text-[10px] space-y-1", className)}>
-      {dataSources.map((source, index) => (
-        <div key={source.id} className="flex items-center gap-1 whitespace-nowrap">
-          <DataSourceBadgePreview
-            dataSourceStyle={dataSourceStyles[source.id]}
-            defaultColor={getDefaultColor(index)}
-          />
-          <span className="font-medium text-black">{source.label}</span>
+      return (
+        <div
+          ref={ref}
+          style={style}
+          onPointerDown={onPointerDown}
+          className={cn(
+            "bg-white/80 rounded shadow p-1 text-[10px] space-y-1",
+            className
+          )}
+        >
+          {dataSources.map((source, index) => (
+            <div key={source.id} className="flex items-center gap-1 whitespace-nowrap">
+              <DataSourceBadgePreview
+                dataSourceStyle={dataSourceStyles[source.id]}
+                defaultColor={getDefaultColor(index)}
+              />
+              <span className="font-medium text-black">{source.label}</span>
+            </div>
+          ))}
         </div>
-      ))}
-    </div>
+      )
+    }
   )
-})
+)
+
+ChartLegend.displayName = "ChartLegend"


### PR DESCRIPTION
## Summary
- allow ChartLegend to forward refs and accept styles
- add drag functionality to ChartPreviewGraph so the legend can be repositioned

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run type-check` *(fails: several type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e49c8fba8832b8cef10f4028d9c35