### PR TITLE
Fix legend drag reset

### DIFF
--- a/components/charts/ChartPreviewGraph.tsx
+++ b/components/charts/ChartPreviewGraph.tsx
@@ -35,6 +35,11 @@ export const ChartPreviewGraph = React.memo(({ editingChart, selectedDataSourceI
   const [legendPos, setLegendPos] = React.useState<{ x: number; y: number } | null>(
     editingChart.legendPosition ?? null
   )
+  const legendPosRef = useRef<{ x: number; y: number } | null>(legendPos)
+
+  useEffect(() => {
+    legendPosRef.current = legendPos
+  }, [legendPos])
   
   // Store scales in refs to avoid recreation during drag
   const scalesRef = useRef<{
@@ -128,8 +133,8 @@ export const ChartPreviewGraph = React.memo(({ editingChart, selectedDataSourceI
     const handleUp = () => {
       window.removeEventListener('pointermove', handleMove)
       window.removeEventListener('pointerup', handleUp)
-      if (legendPos) {
-        setEditingChart?.({ ...editingChart, legendPosition: legendPos })
+      if (legendPosRef.current) {
+        setEditingChart?.({ ...editingChart, legendPosition: legendPosRef.current })
       }
     }
 


### PR DESCRIPTION
## Summary
- keep the final position of the legend when releasing the drag by tracking the latest coordinates via a ref

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run type-check` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_684e51900194832bb12192fdc545b791