### PR TITLE
Store legend position as ratio

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -159,8 +159,8 @@ export interface ChartComponent {
   fileId?: string
   type?: string
   legendPosition?: {
-    x: number
-    y: number
+    xRatio: number
+    yRatio: number
   }
 }
 


### PR DESCRIPTION
## Summary
- store legend coordinates as `{xRatio, yRatio}` in `ChartComponent`
- convert between ratio and absolute coordinates in `ChartPreviewGraph`

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run type-check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e5c59fc80832b9d0c66ffc6fa4d97