### PR TITLE
Add legend toggle to chart editor

### DIFF
--- a/components/charts/ChartEditModal.tsx
+++ b/components/charts/ChartEditModal.tsx
@@ -111,7 +111,7 @@ export function ChartEditModal() {
           onSave={handleSave}
         />
 
-        <div className="grid grid-cols-[7fr_5fr] gap-4 flex-1 min-h-0">
+        <div className="grid grid-cols-2 gap-4 flex-1 min-h-0">
           <div className="border rounded-lg p-4 overflow-hidden h-full flex flex-col">
             <TabNavigation activeTab={activeTab} onTabChange={handleTabChange} />
             

--- a/components/charts/ChartPreviewGraph.tsx
+++ b/components/charts/ChartPreviewGraph.tsx
@@ -330,7 +330,7 @@ export const ChartPreviewGraph = React.memo(({ editingChart, selectedDataSourceI
         </div>
       )}
       <svg ref={svgRef} width={dimensions.width} height={dimensions.height} className="w-full h-full" style={{ visibility: isLoadingData ? 'hidden' : 'visible' }} />
-      {!isLoadingData && selectedDataSourceItems.length > 0 && (
+      {!isLoadingData && editingChart.showLegend !== false && selectedDataSourceItems.length > 0 && (
         <ChartLegend
           ref={legendRef}
           onPointerDown={handleLegendPointerDown}

--- a/components/charts/EditModal/appearance/TitleAndOptionsSection.tsx
+++ b/components/charts/EditModal/appearance/TitleAndOptionsSection.tsx
@@ -64,6 +64,21 @@ export function TitleAndOptionsSection({ editingChart, setEditingChart }: TitleA
             />
             <Label htmlFor="show-title" className="text-sm whitespace-nowrap">Show Title</Label>
           </div>
+          <div className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              id="show-legend"
+              checked={editingChart.showLegend ?? true}
+              onChange={(e) => {
+                setEditingChart({
+                  ...editingChart,
+                  showLegend: e.target.checked,
+                })
+              }}
+              className="rounded"
+            />
+            <Label htmlFor="show-legend" className="text-sm whitespace-nowrap">Show Legend</Label>
+          </div>
         </div>
       </div>
     </div>

--- a/types/index.ts
+++ b/types/index.ts
@@ -101,6 +101,7 @@ export interface ChartComponent {
   id: string
   title: string
   showTitle?: boolean
+  showLegend?: boolean
   data: Array<{ name: string; value: number }>
   xLabel?: string
   yLabel?: string


### PR DESCRIPTION
## Summary
- make ChartEditModal preview panel equal width with editor
- allow toggling legend on/off in appearance options
- hide legend in preview when disabled
- support `showLegend` in `ChartComponent` type

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails to resolve modules)*

------
https://chatgpt.com/codex/tasks/task_e_684e75fec248832b9d78bef261bc286d