### PR TITLE
Consolidate global styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&display=swap');
+@import '../styles/theme.css';
 
 @tailwind base;
 @tailwind components;
@@ -26,77 +27,6 @@ body {
   }
 }
 
-@layer base {
-  :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
-    --radius: 0.5rem;
-    --sidebar-background: 0 0% 98%;
-    --sidebar-foreground: 240 5.3% 26.1%;
-    --sidebar-primary: 240 5.9% 10%;
-    --sidebar-primary-foreground: 0 0% 98%;
-    --sidebar-accent: 240 4.8% 95.9%;
-    --sidebar-accent-foreground: 240 5.9% 10%;
-    --sidebar-border: 220 13% 91%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
-  }
-  .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
-  }
-}
 
 @layer base {
   * {
@@ -155,4 +85,22 @@ body {
       transition-duration: 0.01ms !important;
     }
   }
+}
+
+/* KaTeX Formula Styles */
+.katex-formula {
+  font-size: 1.1em;
+}
+
+.katex-formula .katex {
+  font-size: inherit;
+}
+
+/* Adjust KaTeX display in tooltips */
+.katex-formula.text-base .katex {
+  font-size: 1.2em;
+}
+
+.katex-formula.text-xs .katex {
+  font-size: 0.9em;
 }

--- a/constants/settings.ts
+++ b/constants/settings.ts
@@ -1,0 +1,11 @@
+import { UserSettings } from '@/types/settings'
+
+/**
+ * Default user settings used across the application
+ */
+export const DEFAULT_SETTINGS: UserSettings = {
+  toolDefaults: {
+    parameterSource: 'master'
+  }
+} as const
+

--- a/stores/useSettingsStore.ts
+++ b/stores/useSettingsStore.ts
@@ -1,17 +1,12 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { UserSettings, SettingsStore, ParameterSource } from '@/types/settings'
-
-const defaultSettings: UserSettings = {
-  toolDefaults: {
-    parameterSource: 'master'
-  }
-}
+import { SettingsStore, ParameterSource } from '@/types/settings'
+import { DEFAULT_SETTINGS } from '@/constants/settings'
 
 export const useSettingsStore = create<SettingsStore>()(
   persist(
     (set, get) => ({
-      settings: defaultSettings,
+      settings: DEFAULT_SETTINGS,
       isLoading: false,
 
       updateParameterSource: (source: ParameterSource) => {

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,20 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&display=swap');
-
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
-body {
-  font-family: 'Source Sans 3', 'Noto Sans JP', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-}
-
-@layer utilities {
-  .text-balance {
-    text-wrap: balance;
-  }
-}
-
 @layer base {
   :root {
     --background: 0 0% 100%;
@@ -85,31 +68,4 @@ body {
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
-}
-
-@layer base {
-  * {
-    @apply border-border;
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
-}
-
-/* KaTeX Formula Styles */
-.katex-formula {
-  font-size: 1.1em;
-}
-
-.katex-formula .katex {
-  font-size: inherit;
-}
-
-/* Adjust KaTeX display in tooltips */
-.katex-formula.text-base .katex {
-  font-size: 1.2em;
-}
-
-.katex-formula.text-xs .katex {
-  font-size: 0.9em;
 }


### PR DESCRIPTION
## Summary
- centralize user setting defaults in `constants/settings.ts`
- clean up `useSettingsStore` to use the new constant
- create `styles/theme.css` for theme variables
- import and use the theme in `app/globals.css`
- move KaTeX styles and drop redundant `styles/globals.css`

## Testing
- `npm run lint` *(fails: asks for ESLint config)*
- `npm run type-check` *(fails: several TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e8adb6550832b8a681f9acceaff69