### PR TITLE
Refactor chart edit modals

### DIFF
--- a/components/charts/BulkChartEditModal.tsx
+++ b/components/charts/BulkChartEditModal.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogContent, DialogDescription } from "@/components/ui/dialog
 import { ModalHeader } from "./EditModal/ModalHeader"
 import { TabNavigation, TabType } from "./EditModal/TabNavigation"
 import { TabContent } from "./EditModal/TabContent"
-import { FileNode, ChartComponent, EventInfo } from "@/types"
+import { FileNode, ChartComponent } from "@/types"
 import { useFileStore } from "@/stores/useFileStore"
 
 interface BulkChartEditModalProps {
@@ -17,7 +17,7 @@ interface BulkChartEditModalProps {
 export function BulkChartEditModal({ open, onOpenChange, file }: BulkChartEditModalProps) {
   const { applyBulkSettings } = useFileStore()
 
-  const [activeTab, setActiveTab] = useState<TabType>("datasource")
+  const [activeTab, setActiveTab] = useState<TabType>("parameters")
   const [bulkSettings, setBulkSettings] = useState<ChartComponent>(() => ({
     id: "bulk",
     title: "",
@@ -25,7 +25,6 @@ export function BulkChartEditModal({ open, onOpenChange, file }: BulkChartEditMo
     referenceLines: [],
     fileId: file.id
   } as unknown as ChartComponent))
-  const [selectedDataSourceItems, setSelectedDataSourceItems] = useState<EventInfo[]>([])
 
   useEffect(() => {
     if (open) {
@@ -33,8 +32,7 @@ export function BulkChartEditModal({ open, onOpenChange, file }: BulkChartEditMo
         ? { ...file.charts[0] }
         : { id: "bulk", title: "", data: [], referenceLines: [], fileId: file.id } as ChartComponent
       setBulkSettings(chart)
-      setSelectedDataSourceItems(file.selectedDataSources || [])
-      setActiveTab("datasource")
+      setActiveTab("parameters")
     }
   }, [open, file])
 
@@ -48,20 +46,22 @@ export function BulkChartEditModal({ open, onOpenChange, file }: BulkChartEditMo
     onOpenChange(false)
   }
 
+  const selectedDataSourceItems = file.selectedDataSources || []
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-7xl w-[90vw] h-[90vh] flex flex-col overflow-hidden" hideCloseButton>
         <DialogDescription className="sr-only">Bulk edit chart settings</DialogDescription>
         <ModalHeader title={`${file.name} Bulk Edit`} onCancel={handleCancel} onSave={handleSave} />
         <div className="flex-1 min-h-0 flex flex-col">
-          <TabNavigation activeTab={activeTab} onTabChange={setActiveTab} />
+          <TabNavigation activeTab={activeTab} onTabChange={setActiveTab} includeDataSourceTab={false} />
           <div className="flex-1 min-h-0 overflow-y-auto">
             <TabContent
               activeTab={activeTab}
               editingChart={bulkSettings}
               setEditingChart={setBulkSettings}
               selectedDataSourceItems={selectedDataSourceItems}
-              setSelectedDataSourceItems={setSelectedDataSourceItems}
+              includeDataSourceTab={false}
             />
           </div>
         </div>

--- a/components/charts/ChartEditModal.tsx
+++ b/components/charts/ChartEditModal.tsx
@@ -5,32 +5,22 @@ import { Dialog, DialogContent, DialogDescription } from "@/components/ui/dialog
 import { useUIStore } from "@/stores/useUIStore"
 import { useFileStore } from "@/stores/useFileStore"
 import { ChartPreview } from "./ChartPreview"
-import { EventInfo } from "@/types"
 import { ModalHeader } from "./EditModal/ModalHeader"
 import { TabNavigation, TabType } from "./EditModal/TabNavigation"
 import { TabContent } from "./EditModal/TabContent"
 
 export function ChartEditModal() {
   const { editingChart, editModalOpen, setEditingChart, setEditModalOpen } = useUIStore()
-  const { openTabs, activeTab: activeFileTab, updateFileCharts, updateFileDataSources } = useFileStore()
-  const [activeTab, setActiveTab] = useState<TabType>("datasource")
-  const [selectedDataSourceItems, setSelectedDataSourceItems] = useState<EventInfo[]>([])
+  const { openTabs, activeTab: activeFileTab, updateFileCharts } = useFileStore()
+  const [activeTab, setActiveTab] = useState<TabType>("parameters")
   const [dataSourceStyles, setDataSourceStyles] = useState<{ [dataSourceId: string]: any }>({})
 
-  // Initialize selectedDataSourceItems and dataSourceStyles from FileNode when modal opens
+  // Initialize dataSourceStyles from FileNode when modal opens
   React.useEffect(() => {
     if (editModalOpen && editingChart) {
       const targetFileId = editingChart.fileId || activeFileTab
       const currentFile = openTabs.find(tab => tab.id === targetFileId)
-      
-      // Use FileNode's selectedDataSources as the source of truth
-      if (currentFile?.selectedDataSources) {
-        setSelectedDataSourceItems(currentFile.selectedDataSources)
-      } else {
-        setSelectedDataSourceItems([])
-      }
-      
-      // Also get dataSourceStyles
+
       if (currentFile?.dataSourceStyles) {
         setDataSourceStyles(currentFile.dataSourceStyles)
       } else {
@@ -39,10 +29,10 @@ export function ChartEditModal() {
     }
   }, [editModalOpen, editingChart?.id, openTabs, activeFileTab])
   
-  // Reset to datasource tab when modal opens
+  // Reset to parameters tab when modal opens
   React.useEffect(() => {
     if (editModalOpen) {
-      setActiveTab("datasource")
+      setActiveTab("parameters")
     }
   }, [editModalOpen])
 
@@ -81,9 +71,6 @@ export function ChartEditModal() {
       
       // Save to file store
       updateFileCharts(currentFile.id, updatedCharts)
-      
-      // Also update the file's data sources
-      updateFileDataSources(currentFile.id, selectedDataSourceItems)
     }
     
     setEditModalOpen(false)
@@ -99,6 +86,10 @@ export function ChartEditModal() {
     setActiveTab(newTab)
   }
 
+  const targetFileId = editingChart.fileId || activeFileTab
+  const currentFile = openTabs.find(tab => tab.id === targetFileId)
+  const selectedDataSourceItems = currentFile?.selectedDataSources || []
+
   return (
     <Dialog open={editModalOpen} onOpenChange={setEditModalOpen}>
       <DialogContent className="max-w-7xl w-[90vw] h-[90vh] flex flex-col overflow-hidden" hideCloseButton>
@@ -113,7 +104,7 @@ export function ChartEditModal() {
 
         <div className="grid grid-cols-2 gap-4 flex-1 min-h-0">
           <div className="border rounded-lg p-4 overflow-hidden h-full flex flex-col">
-            <TabNavigation activeTab={activeTab} onTabChange={handleTabChange} />
+            <TabNavigation activeTab={activeTab} onTabChange={handleTabChange} includeDataSourceTab={false} />
             
             <div className="flex-1 min-h-0">
               <TabContent
@@ -121,7 +112,7 @@ export function ChartEditModal() {
                 editingChart={editingChart}
                 setEditingChart={setEditingChart}
                 selectedDataSourceItems={selectedDataSourceItems}
-                setSelectedDataSourceItems={setSelectedDataSourceItems}
+                includeDataSourceTab={false}
               />
             </div>
           </div>

--- a/components/charts/EditModal/TabContent.tsx
+++ b/components/charts/EditModal/TabContent.tsx
@@ -11,19 +11,22 @@ interface TabContentProps {
   activeTab: TabType
   editingChart: ChartComponent
   setEditingChart: (chart: ChartComponent) => void
-  selectedDataSourceItems: EventInfo[]
-  setSelectedDataSourceItems: React.Dispatch<React.SetStateAction<EventInfo[]>>
+  selectedDataSourceItems?: EventInfo[]
+  setSelectedDataSourceItems?: React.Dispatch<React.SetStateAction<EventInfo[]>>
+  includeDataSourceTab?: boolean
 }
 
 export function TabContent({
   activeTab,
   editingChart,
   setEditingChart,
-  selectedDataSourceItems,
-  setSelectedDataSourceItems
+  selectedDataSourceItems = [],
+  setSelectedDataSourceItems,
+  includeDataSourceTab = true
 }: TabContentProps) {
   switch (activeTab) {
     case "datasource":
+      if (!includeDataSourceTab || !setSelectedDataSourceItems) return null
       return (
         <div className="h-full overflow-y-auto">
           <DataSourceTab

--- a/components/charts/EditModal/TabNavigation.tsx
+++ b/components/charts/EditModal/TabNavigation.tsx
@@ -8,15 +8,19 @@ export type TabType = "datasource" | "parameters" | "appearance"
 interface TabNavigationProps {
   activeTab: TabType
   onTabChange: (tab: TabType) => void
+  includeDataSourceTab?: boolean
 }
 
-const tabs: { value: TabType; label: string }[] = [
+const allTabs: { value: TabType; label: string }[] = [
   { value: "datasource", label: "DataSource" },
   { value: "parameters", label: "Parameters" },
   { value: "appearance", label: "Appearance" }
 ]
 
-export function TabNavigation({ activeTab, onTabChange }: TabNavigationProps) {
+export function TabNavigation({ activeTab, onTabChange, includeDataSourceTab = true }: TabNavigationProps) {
+  const tabs = includeDataSourceTab
+    ? allTabs
+    : allTabs.filter((t) => t.value !== "datasource")
   return (
     <div className="flex gap-2 mb-4">
       {tabs.map((tab) => (


### PR DESCRIPTION
## Summary
- add `includeDataSourceTab` option to tab navigation and content
- remove data source editing from ChartEditModal and BulkChartEditModal
- rely on file data sources in modals

## Testing
- `npm run lint` *(fails: requires interactive configuration)*
- `npm run type-check` *(fails: type errors unrelated to changes)*

------
https://chatgpt.com/codex/tasks/task_e_684ea8bb6ec0832b8031d79eca8b8827