### PR TITLE
Set default legend mode

### DIFF
--- a/components/charts/ChartLegend.tsx
+++ b/components/charts/ChartLegend.tsx
@@ -27,7 +27,7 @@ export const ChartLegend = React.memo(
     }, ref) => {
       if (!dataSources || dataSources.length === 0) return null
 
-      const mode = editingChart.legendMode || 'both'
+      const mode = editingChart.legendMode || 'datasource'
       const items: { key: string; label: string; colorIndex: number; dsId?: string }[] = []
 
       if (mode === 'datasource') {

--- a/components/charts/EditModal/appearance/PlotStyleTable.tsx
+++ b/components/charts/EditModal/appearance/PlotStyleTable.tsx
@@ -18,8 +18,14 @@ interface PlotStyleTableProps {
 
 export function PlotStyleTable({ editingChart, setEditingChart, selectedDataSourceItems }: PlotStyleTableProps) {
   const [appearanceMode, setAppearanceMode] = useState<"datasource" | "parameter" | "both">(
-    editingChart.legendMode || "both"
+    editingChart.legendMode || "datasource"
   )
+
+  React.useEffect(() => {
+    if (!editingChart.legendMode) {
+      setEditingChart({ ...editingChart, legendMode: "datasource" })
+    }
+  }, [editingChart.legendMode])
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- default plot style mode to `datasource`
- default legend mode to `datasource`

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run type-check` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684f7e5fb770832bb20a285e51675036